### PR TITLE
add support for cypress 12

### DIFF
--- a/cypress/e2e/contains.cy.js
+++ b/cypress/e2e/contains.cy.js
@@ -4,7 +4,7 @@
 import '../../src'
 
 describe('cy.contains support', () => {
-  before(() => {
+  beforeEach(() => {
     cy.visit('cypress/index.html')
   })
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Gleb Bahmutov <gleb.bahmutov@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "cypress": "11.2.0",
+    "cypress": "^12.17.1",
     "prettier": "^2.7.1",
     "semantic-release": "^19.0.5"
   },


### PR DESCRIPTION
This adds support for cypress 12 (tested with 12.17.1), but older versions (< 12) won't work anymore.
All of your tests passed locally. Also, all tests of our angular 16 app passed.
We use cypress-if quite a lot in this app.
